### PR TITLE
Add Port Arbitration MRPC Command implementation.

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -780,6 +780,120 @@ static int temp(int argc, char **argv)
 	return 0;
 }
 
+static void arbitration_print(enum switchtec_arbitration_mode mode,
+					int ports, int *weights)
+{
+	int p;
+
+	printf("Mode = %u : %s\n", mode, switchtec_arbitration_mode(mode));
+
+	printf("Port  :");
+	for (p = 0; p < ports; p++)
+		printf("%4d", p);
+	printf("\nWeight:");
+	for (p = 0; p < ports; p++)
+		printf("%4d", weights[p]);
+	printf("\n");
+}
+
+static int arbitration_get(int argc, char **argv)
+{
+	const char *desc = "Get Arbitration info for physical port";
+	int ports;
+	enum switchtec_arbitration_mode mode;
+	int weights[SWITCHTEC_MAX_ARBITRATION_WEIGHTS];
+
+	static struct {
+		struct switchtec_dev *dev;
+		int port;
+	} cfg = {};
+	const struct argconfig_options opts[] = {
+		DEVICE_OPTION,
+		{"port", 'p', "", CFG_POSITIVE, &cfg.port, required_argument,
+			"physical port number (0-47)"},
+		{NULL} };
+
+	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
+
+	if (cfg.port < 0 || cfg.port >= SWITCHTEC_MAX_PORTS) {
+		argconfig_print_usage(opts);
+		fprintf(stderr, "The --port argument is invalid!\n");
+		return 1;
+	}
+
+	printf("Physical port:%d\n", cfg.port);
+
+	ports = switchtec_arbitration_get(cfg.dev, cfg.port, &mode, weights);
+
+	if (ports < 0) {
+		switchtec_perror("arbitration get");
+		return ports;
+	}
+
+	arbitration_print(mode, ports, weights);
+
+	return 0;
+}
+
+static int arbitration_set(int argc, char **argv)
+{
+	const char *desc = "Set Arbitration info for physical port";
+	int p, ports;
+	enum switchtec_arbitration_mode mode;
+	int in_weights[SWITCHTEC_MAX_ARBITRATION_WEIGHTS];
+	int out_weights[SWITCHTEC_MAX_ARBITRATION_WEIGHTS];
+
+	static struct {
+		struct switchtec_dev *dev;
+		int port;
+		int mode;
+		int weight;
+	} cfg = {};
+	const struct argconfig_options opts[] = {
+		DEVICE_OPTION,
+		{"port", 'p', "", CFG_POSITIVE, &cfg.port, required_argument,
+			"physical port number (0-47)"},
+		{"mode", 'm', "", CFG_POSITIVE, &cfg.mode, required_argument,
+			"arbitration mode to set"},
+		{"weight", 'w', "", CFG_POSITIVE, &cfg.weight,
+			required_argument, "weight value to set"},
+		{NULL} };
+
+	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
+
+	if (cfg.port < 0 || cfg.port >= SWITCHTEC_MAX_PORTS) {
+		argconfig_print_usage(opts);
+		fprintf(stderr, "The --port argument is invalid!\n");
+		return 1;
+	}
+
+	if (cfg.weight < 0 || cfg.weight >= 255) {
+		argconfig_print_usage(opts);
+		fprintf(stderr, "The --weight argument is invalid!\n");
+		return 1;
+	}
+
+	printf("Physical port:%d\n", cfg.port);
+	printf("Mode = %u : %s\n", cfg.mode,
+				switchtec_arbitration_mode(cfg.mode));
+	printf("Weight for all Ports = %d\n", cfg.weight);
+
+	for (p = 0; p < SWITCHTEC_MAX_ARBITRATION_WEIGHTS; p++)
+		in_weights[p] = cfg.weight;
+
+	ports = switchtec_arbitration_set(cfg.dev, cfg.port,
+				cfg.mode, in_weights, &mode, out_weights);
+
+	if (ports < 0) {
+		switchtec_perror("arbitration set");
+		return ports;
+	}
+
+	arbitration_print(mode, ports, out_weights);
+
+	return 0;
+}
+
 static int port_bind_info(int argc, char **argv)
 {
 	const char *desc = "Bind info for physical port";
@@ -1746,6 +1860,8 @@ static const struct cmd commands[] = {
 	CMD(log_dump, "Dump firmware log to a file"),
 	CMD(test, "Test if switchtec interface is working"),
 	CMD(temp, "Return the switchtec die temperature"),
+	CMD(arbitration_get, "Return arbitration weights for a physical port"),
+	CMD(arbitration_set, "Set arbitration weight for a physical port"),
 	CMD(port_bind_info, "Return binding info for a physical port"),
 	CMD(port_bind, "Bind switchtec logical and physical ports"),
 	CMD(port_unbind, "Unbind switchtec logical port from physical port"),

--- a/inc/switchtec/arbitration.h
+++ b/inc/switchtec/arbitration.h
@@ -1,0 +1,51 @@
+/*
+ * Microsemi Switchtec(tm) PCIe Management Library
+ * Copyright (c) 2017, Microsemi Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef LIBSWITCHTEC_ARBITRATION_H
+#define LIBSWITCHTEC_ARBITRATION_H
+
+#include <stdint.h>
+#include <switchtec/switchtec.h>
+
+#pragma pack(push, 1)
+
+struct arbitration_in {
+	uint8_t sub_cmd_id;
+	uint8_t port_id;
+	uint8_t mode;
+	uint8_t weights[SWITCHTEC_MAX_ARBITRATION_WEIGHTS];
+	uint8_t reserved1;
+};
+
+struct arbitration_out {
+	uint8_t mode;
+	uint8_t weights[SWITCHTEC_MAX_ARBITRATION_WEIGHTS];
+	uint8_t reserved1;
+	uint8_t reserved2;
+	uint8_t reserved3;
+};
+
+#pragma pack(pop)
+
+#endif

--- a/inc/switchtec/mrpc.h
+++ b/inc/switchtec/mrpc.h
@@ -111,6 +111,9 @@ enum mrpc_sub_cmd {
 	MRPC_PORT_BIND = 0,
 	MRPC_PORT_UNBIND = 1,
 	MRPC_PORT_INFO = 2,
+
+	MRPC_ARB_GET = 0,
+	MRPC_ARB_SET = 1,
 };
 
 #endif

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -48,6 +48,7 @@ struct switchtec_dev;
 #define SWITCHTEC_MAX_PARTS  48
 #define SWITCHTEC_MAX_PORTS  48
 #define SWITCHTEC_MAX_STACKS 8
+#define SWITCHTEC_MAX_ARBITRATION_WEIGHTS 56
 #define SWITCHTEC_MAX_EVENT_COUNTERS 64
 #define SWITCHTEC_UNBOUND_PORT 255
 #define SWITCHTEC_PFF_PORT_VEP 100
@@ -327,6 +328,27 @@ int switchtec_event_wait_for(struct switchtec_dev *dev,
 			     enum switchtec_event_id e, int index,
 			     struct switchtec_event_summary *res,
 			     int timeout_ms);
+
+/******** ARBITRATION Management ********/
+
+/**
+ * @brief Describe the port arbitration mode
+ * @see switchtec_arbitration_get()
+ */
+enum switchtec_arbitration_mode {
+	SWITCHTEC_ARBITRATION_FRR,
+	SWITCHTEC_ARBITRATION_WRR,
+};
+
+const char *switchtec_arbitration_mode(
+				const enum switchtec_arbitration_mode mode);
+
+int switchtec_arbitration_get(struct switchtec_dev *dev, int port_id,
+			enum switchtec_arbitration_mode *mode, int *weights);
+
+int switchtec_arbitration_set(struct switchtec_dev *dev, int port_id,
+		enum switchtec_arbitration_mode in_mode, int *in_weights,
+		enum switchtec_arbitration_mode *out_mode, int *out_weights);
 
 /******** FIRMWARE Management ********/
 

--- a/lib/arbitration.c
+++ b/lib/arbitration.c
@@ -1,0 +1,163 @@
+/*
+ * Microsemi Switchtec(tm) PCIe Management Library
+ * Copyright (c) 2017, Microsemi Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/**
+ * @file
+ * @brief Switchtec core library functions for port arbitration
+ */
+
+#define SWITCHTEC_LIB_CORE
+
+#include "switchtec/arbitration.h"
+#include "switchtec_priv.h"
+#include "switchtec/switchtec.h"
+#include "switchtec/endian.h"
+
+#include <stddef.h>
+#include <errno.h>
+
+/**
+ * @defgroup Port Arbitration
+ * @brief Setup and query port arbitration in the switch.
+ * Switchtec supports two types of Port Arbitration Modes:
+ *   - Fixed Round Robin (FRR) and
+ *   - Weighted Round Robin (WRR)
+ * In Weighted Round Robin (WRR) mode, the arbitration initial count for all
+ * ports needs to be specified.The MRPC Port Arbitration Command can be used to
+ * set or get the port arbitration mode and initial count in WRR mode.
+ *
+ * switchtec_arbitration_get() may be used to get port arbitration mode and
+ * the WRR arbitration initial count.
+ *
+ * switchtec_arbitration_set() may be used to set port arbitration mode and
+ * the WRR arbitration initial count for WRR mode. If mode set to FRR,
+ * then arbitration initial count fields will be ignored.
+ *
+ * @{
+ */
+
+/**
+ * @brief Return a string describing the arbitration mode
+ * @param[out] info Information structure to return the type string for
+ * @return Type string
+ */
+const char *switchtec_arbitration_mode(
+				const enum switchtec_arbitration_mode mode)
+{
+	switch (mode) {
+	case SWITCHTEC_ARBITRATION_FRR: return "Fixed Round Robin (FRR)";
+	case SWITCHTEC_ARBITRATION_WRR: return "Weighted Round Robin (WRR)";
+
+	default: return "UNKNOWN";
+	}
+}
+
+/**
+ * @brief Get all ports arbitration
+ * @param[in]  dev	Switchtec device handle
+ * @param[in]  port_id	The physical port number (0-47)
+ * @param[out] mode	The arbitration mode
+ * @param[out] weights	A list of current weight values for each physical port
+ * @return Number of ports in arbitration list or a negative value on failure
+ */
+int switchtec_arbitration_get(struct switchtec_dev *dev, int port_id,
+			enum switchtec_arbitration_mode *mode, int *weights)
+{
+	int i, ret;
+	int nr_ports = 0;
+	struct arbitration_out response;
+	struct arbitration_in sub_cmd_id = {
+		.sub_cmd_id = MRPC_ARB_GET,
+		.port_id = port_id
+	};
+
+	if (!mode || !weights) {
+		errno = EINVAL;
+		return -errno;
+	}
+
+	ret = switchtec_cmd(dev, MRPC_ARB, &sub_cmd_id,
+			sizeof(sub_cmd_id), &response, sizeof(response));
+
+	if (ret)
+		return ret;
+
+	*mode = response.mode;
+
+	for (i = 0; i < SWITCHTEC_MAX_ARBITRATION_WEIGHTS; i++) {
+		weights[i] = response.weights[i];
+		nr_ports++;
+	}
+
+	return nr_ports;
+}
+
+/**
+ * @brief Set port arbitration weights
+ * @param[in]  dev	Switchtec device handle
+ * @param[in]  port_id	The physical port number (0-47)
+ * @param[in]  in_mode	The arbitration mode to set
+ * @param[in]  in_weights	A list of weights for each physical port to set
+ * @param[out] out_mode	The arbitration mode
+ * @param[out] out_weights	A list of weight values for each physical port
+ * @return Number of ports in arbitration list or a negative value on failure
+ */
+int switchtec_arbitration_set(struct switchtec_dev *dev, int port_id,
+		enum switchtec_arbitration_mode in_mode, int *in_weights,
+		enum switchtec_arbitration_mode *out_mode, int *out_weights)
+{
+	int i, ret;
+	int nr_ports = 0;
+	struct arbitration_out response;
+	struct arbitration_in sub_cmd_id = {
+		.sub_cmd_id = MRPC_ARB_SET,
+		.port_id = port_id,
+		.mode = in_mode
+	};
+
+	for (i = 0; i < SWITCHTEC_MAX_ARBITRATION_WEIGHTS; i++)
+		sub_cmd_id.weights[i] = in_weights[i];
+
+	if (!out_mode || !out_weights) {
+		errno = EINVAL;
+		return -errno;
+	}
+
+	ret = switchtec_cmd(dev, MRPC_ARB, &sub_cmd_id,
+			sizeof(sub_cmd_id), &response, sizeof(response));
+
+	if (ret)
+		return ret;
+
+	*out_mode = response.mode;
+
+	for (i = 0; i < SWITCHTEC_MAX_ARBITRATION_WEIGHTS; i++) {
+		out_weights[i] = response.weights[i];
+		nr_ports++;
+	}
+
+	return nr_ports;
+}
+
+/**@}*/


### PR DESCRIPTION
    Switchtec supports two types of Port Arbitration Modes:
        * Fixed Round Robin (FRR) and
        * Weighted Round Robin (WRR)
    The MRPC Port Arbitration Command can be used to set or get the port
    arbitration mode and initial count in WRR mode.